### PR TITLE
Add Source Sans 3 font from Google Fonts to common design

### DIFF
--- a/projects/common/src/styles/_variables.less
+++ b/projects/common/src/styles/_variables.less
@@ -22,7 +22,7 @@
 @spacing-xxl: 48px;
 
 // Typography
-@font-family-base: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+@font-family-base: 'Source Sans 3', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 @font-family-heading: @font-family-base;
 @font-family-mono: 'Courier New', Courier, monospace;
 

--- a/projects/common/src/styles/global.less
+++ b/projects/common/src/styles/global.less
@@ -6,8 +6,8 @@
 @import './_reset.less';
 @import './_typography.less';
 
-// Example: Import Google Fonts
-// @import (css) url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
+// Import Google Fonts - Source Sans 3
+@import (css) url('https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@300;400;700&display=swap');
 
 // Global utility classes
 .container {


### PR DESCRIPTION
## Summary

- Added Source Sans 3 font from Google Fonts with weights 300 (light), 400 (normal), and 700 (bold)
- Updated the base font family variable to use Source Sans 3 as the primary font
- Font automatically applies to all apps (main and sample-reflect) via common styles

## Changes Made

1. Updated `projects/common/src/styles/global.less`:
   - Added Google Fonts import for Source Sans 3
   
2. Updated `projects/common/src/styles/_variables.less`:
   - Changed `@font-family-base` to include 'Source Sans 3' as the primary font with system font fallbacks

## Test Plan

- [x] Built main app successfully
- [x] Built sample-reflect app successfully
- [x] Verified no build errors or warnings

fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)